### PR TITLE
update haskell project

### DIFF
--- a/src/haskell/chessbot.cabal
+++ b/src/haskell/chessbot.cabal
@@ -3,7 +3,6 @@ cabal-version:       2.2
 name:                chessbot
 version:             0.1.0.0
 license:             BSD-3-Clause
-license-file:        LICENSE
 build-type:          Simple
 extra-source-files:  README.md
 

--- a/src/haskell/stack.yaml
+++ b/src/haskell/stack.yaml
@@ -3,4 +3,4 @@ snapshot:
 
 extra-deps:
 - git: https://github.com/chayleaf/shiro-chessapi-hs.git
-  commit: 643d9d960c1ed73228d9b1b03504c01b52251a87
+  commit: 93d34b22a0525143f2e8c13a88dcbb27b84d6e4a

--- a/src/haskell/stack.yaml.lock
+++ b/src/haskell/stack.yaml.lock
@@ -5,14 +5,14 @@
 
 packages:
 - completed:
-    commit: 643d9d960c1ed73228d9b1b03504c01b52251a87
+    commit: 93d34b22a0525143f2e8c13a88dcbb27b84d6e4a
     git: https://github.com/chayleaf/shiro-chessapi-hs.git
     name: chessapi
     pantry-tree:
-      sha256: ba914be07263adb1a5d95c3fa10d2e8bd2e94d6daffc23643dc7defff27c5377
-      size: 1624
+      sha256: 27aeb8318a939ec7e6e207febc7e4ea153afe025881905a6d739d57b567e72b4
+      size: 2240
     version: 0.1.0.0
   original:
-    commit: 643d9d960c1ed73228d9b1b03504c01b52251a87
+    commit: 93d34b22a0525143f2e8c13a88dcbb27b84d6e4a
     git: https://github.com/chayleaf/shiro-chessapi-hs.git
 snapshots: []


### PR DESCRIPTION
mostly to remove `license-file:  LICENSE` since it stopped building after i removed the `LICENSE` file that was part of the template

it also updates the bindings with the new functions added in the last few days (get opponent move, full moves/half moves) and threads.h over pthreads

i'll send another pr after windows support gets ironed out to make sure windows onboarding is easy