### PR TITLE
C: added pthread.h compiler fallback

### DIFF
--- a/src/c/chessapi.c
+++ b/src/c/chessapi.c
@@ -7,8 +7,8 @@
 #include <time.h>
 
 /// TESTING ONLY ///
-#undef __STDC_NO_THREADS__
-#define __STDC_NO_THREADS__ 1
+//#undef __STDC_NO_THREADS__
+//#define __STDC_NO_THREADS__ 1
 /// TESTING ONLY ///
 
 #if __STDC_NO_THREADS__


### PR DESCRIPTION
support of threads.h and pthread.h is spotty; both are well-supported on linux, but mac only has pthread.h and windows more often has threads.h than pthread.h, so supporting both seems worthwhile if it can be reliably done