### PR TITLE
Add a variant of chess_get_legal_moves() that writes moves to a passed array.

### DIFF
--- a/src/c/chessapi.c
+++ b/src/c/chessapi.c
@@ -1231,10 +1231,10 @@ static Move *get_legal_moves(Board *board, int *len) {
     // This is very likely enough to hold all moves
     const int CONSERVATIVE_SIZE = 256;
     
-    Move *moves = malloc(CONSERVATIVE_SIZE * sizeof(Move));
+    Move *moves = (Move*)malloc(CONSERVATIVE_SIZE * sizeof(Move));
     *len = chess_get_legal_moves_inplace(board, moves, CONSERVATIVE_SIZE);
 
-    moves = realloc(moves, *len * sizeof(Move));
+    moves = (Move*)realloc(moves, *len * sizeof(Move));
 
     if (*len > CONSERVATIVE_SIZE)
     {
@@ -1712,7 +1712,7 @@ static int get_legal_moves_inplace(Board *board, Move *moves, size_t maxlen_move
     free(pseudo_moves);
     free(opp_pseudo_moves);
 
-    return len_moves;
+    return (int)len_moves;
 }
 
 // Starts the Chess API internals, and returns the interface to the bot for access.

--- a/src/c/chessapi.h
+++ b/src/c/chessapi.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <stddef.h>
 #include <stdbool.h>
 #include "bitboard.h"
 
@@ -83,6 +84,16 @@ Caller must free array
 \return A pointer to the start of an array of moves
 */
 DLLEXPORT Move *chess_get_legal_moves(Board *board, int *len);
+
+//! Returns legal moves
+/*!
+If the array is smaller than available legal moves then writing will stop at array boundary but this won't affect the return value.
+\param board The board to get legal moves on
+\param moves Target array moves are written to
+\param maxlen_moves The size of the passed moves array
+\return The number of legal moves
+*/
+DLLEXPORT int chess_get_legal_moves_inplace(Board *board, Move *moves, size_t maxlen_moves);
 
 //! Returns whether it is white's turn or not
 /*!


### PR DESCRIPTION
This adds `chess_get_legal_moves_inplace()` that does not allocate memory for moves. Instead it writes found moves to an array. It will stop writing once it reaches the end of the array. `chess_get_legal_moves()` is now a wrapper for the in-place version.

I did some local testing with my own bot using `chess_get_legal_moves()` and it seems to still work fine.
It actually feels a lot snappier now, even with the allocating wrapper.

We still allocate and free pseudo legal moves, but I guess that's a problem for later. :sweat_smile: 