### PR TITLE
Add testing tool for `chess_get_legal_moves()`.

### DIFF
--- a/src/c/chessapi.c
+++ b/src/c/chessapi.c
@@ -1800,11 +1800,9 @@ Board *chess_clone_board(Board *board) {
 }
 
 Move *chess_get_legal_moves(Board *board, int *len) {
-    if (API == NULL) start_chess_api();
     return get_legal_moves(board, len);
 }
 int chess_get_legal_moves_inplace(Board *board, Move *moves, size_t maxlen_moves) {
-    if (API == NULL) start_chess_api();
     return get_legal_moves_inplace(board, moves, maxlen_moves);
 }
 
@@ -1840,7 +1838,6 @@ void chess_undo_move(Board *board) {
 }
 
 void chess_free_board(Board *board) {
-    if (API == NULL) start_chess_api();
     free_board(board);
 }
 
@@ -1876,6 +1873,18 @@ void chess_push(Move move)
 void chess_done() {
     if (API == NULL) start_chess_api();
     interface_done();
+}
+
+Board* chess_board_from_fen(const char *fen) {
+    Board *board = (Board*)malloc(sizeof(Board));
+    memset(board, 0, sizeof(Board));
+    set_board_from_fen(board, fen);
+    board->refcount = 1;
+    return board;
+}
+
+void chess_dump_move(char *buffer, Move move) {
+    dump_move(buffer, move);
 }
 
 BitBoard chess_get_bitboard(Board *board, PlayerColor color, PieceType piece_type) {

--- a/src/c/chessapi.h
+++ b/src/c/chessapi.h
@@ -264,6 +264,21 @@ This method will block until the opponent's turn has passed.
 */
 DLLEXPORT void chess_done();
 
+//! Generates a board from a FEN string
+/*!
+Caller must free the board with free_board
+\sa chess_free_board()
+\param fen A FEN string to generate the board from.
+\return The generated board
+*/
+DLLEXPORT Board* chess_board_from_fen(const char *fen);
+
+//! Get algebraic notation string for chess move
+/*!
+\param buffer The output buffer, should hold at least 7 bytes.
+\param move The move.
+*/
+DLLEXPORT void chess_dump_move(char *buffer, Move move);
 
 ///// TIME MANAGEMENT /////
 

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,24 @@
+# API test program
+
+This is a test data generator script and a program to test if the C chess API is able to find all valid moves for a board.
+
+Generate test data with:
+
+```
+./gen_testdata.py >testdata
+```
+You need to have `uv` installed for this. Alternatively install the `chess` module with pip and run the script with `python3`.
+
+Build the tester binary with:
+
+```
+g++ -O3 --std=c++20 -I../src/c chess_api_tester.cpp ../src/c/chessapi.c ../src/c/bitboard.c -o chess_api_tester
+```
+
+Run the tester with:
+
+```
+cat testdata | ./chess_api_tester
+```
+
+The tester will print out test cases where the found move set doesn't match the expected ones. The output can be captured and used as input data for debugging.

--- a/test/chess_api_tester.cpp
+++ b/test/chess_api_tester.cpp
@@ -1,0 +1,88 @@
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <set>
+
+#include <chessapi.h>
+
+int main()
+{
+	std::string fen;
+
+	int return_value = 0;
+	
+	while (std::getline(std::cin, fen))
+	{
+		if (fen[0] == '#')
+		{
+			// Comment line - skip
+			continue;
+		}
+
+		std::string moves;
+
+		do
+		{
+			if (!std::getline(std::cin, moves))
+			{
+				std::cerr << "Unexpected EOF" << std::endl;
+				return 2;
+			}
+
+		} while(moves[0] == '#');
+
+		std::stringstream ss(moves);
+		std::string move;
+		std::set<std::string> move_set;
+		
+		while (ss >> move)
+		{
+			move_set.insert(move);
+		}
+
+		Board *board = chess_board_from_fen(fen.c_str());
+
+		int num_api_moves;
+		Move *api_moves = chess_get_legal_moves(board, &num_api_moves);
+
+		bool mismatch_found = false;
+		for (int i = 0; i < num_api_moves; ++i)
+		{
+			char buffer[8];
+			chess_dump_move(buffer, api_moves[i]);
+
+			std::string api_move(buffer);
+			if (!move_set.contains(api_move))
+			{
+				std::cout << "# Illegal move \"" << api_move << "\":" << std::endl;
+				mismatch_found = true;
+			}
+			else
+			{
+				move_set.erase(api_move);
+			}				
+		}
+
+		if (move_set.size() > 0)
+		{
+			for (auto move : move_set)
+			{
+				std::cout << "# Missing move \"" << move << "\":" << std::endl;
+				mismatch_found = true;
+			}
+		}
+		
+		if (mismatch_found)
+		{
+			// Dump board with mismatch for further testing
+			std::cout << fen << std::endl;
+			std::cout << moves << std::endl;
+			return_value = 1;
+		}
+
+		free(api_moves);
+		chess_free_board(board);
+	}
+	
+	return return_value;
+}

--- a/test/gen_testdata.py
+++ b/test/gen_testdata.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env -S uv --quiet run --script
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "chess",
+# ]
+# ///
+
+import chess
+import random
+
+for i in range(1000):
+    board = chess.Board()
+
+    j = 0
+    while not board.is_checkmate() and not board.is_stalemate():
+        board.push(random.choice(list(board.legal_moves)))
+        print(board.fen())
+        print(' '.join((m.uci() for m in board.legal_moves)))
+
+        j += 1
+        if j > 150:
+            break


### PR DESCRIPTION
This adds a C++ program that's testing if `chess_get_legal_moves()` gives valid output. It loads board configurations from FEN strings and checks if the found moves match a list generated by the `python-chess` module.

This found a bunch of cases where moves are missing:
[failures.txt](https://github.com/user-attachments/files/22575232/failures.txt)

I had to do some changes to the chess C api for this. I exposed `chess_board_from_fen()` and `chess_dump_move()` and also needed to remove a bunch of cases where a function would attempt to start the API thread (since we don't want to connect to UCI here).